### PR TITLE
Set ESX as local variable

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -1,4 +1,4 @@
-ESX = nil
+local ESX = nil
 
 TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 


### PR DESCRIPTION
I think it's useless to have ESX as global variable beacause it's used only in one file.